### PR TITLE
adding max-width

### DIFF
--- a/src/sass/partials/_main-section.scss
+++ b/src/sass/partials/_main-section.scss
@@ -58,6 +58,7 @@
     @include desktop {
       font-size: var(--font-20);
       line-height: var(--line-height-medium);
+      max-width: 395px;
     }
   }
   &__movie-genres {


### PR DESCRIPTION
Prosty bugfix, zapobiegający rozjeżdżaniu się kart filmów przez zbyt długie tytuły filmów w wersji desktop