### PR TITLE
bugFix modal closing

### DIFF
--- a/src/javascript/modal.js
+++ b/src/javascript/modal.js
@@ -117,6 +117,11 @@ function fillModal(movie) {
 </div>`,
   );
 
+  const modalWindow = document.querySelector('#modal');
+  modalWindow.addEventListener('click', event => {
+    event.stopPropagation();
+  });
+
   const closeBtn = document.querySelector('#modal-close-button');
   closeBtn.addEventListener('click', closeModal);
 }


### PR DESCRIPTION
Poprawione zostało zamykanie na modala. Kliknięcie na białe tło modala nic nie robi, tylko backdrop Esc i X zamykają modal